### PR TITLE
Update example to match new Viewer + add libigl as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libigl"]
+	path = libigl
+	url = https://github.com/libigl/libigl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libigl"]
-	path = libigl
-	url = https://github.com/libigl/libigl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,4 @@ find_package(LIBIGL REQUIRED QUIET)
 # Add your project files
 file(GLOB SRCFILES *.cpp)
 add_executable(${PROJECT_NAME}_bin ${SRCFILES})
-target_link_libraries(${PROJECT_NAME}_bin igl::core igl::viewer)
+target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl_glfw)

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ A glfw app should launch displaying a 3D cube.
 ## Dependencies
 
 The only dependencies are stl, eigen, [libigl](libigl.github.io/libigl/) and
-the dependencies of the `igl::viewer::Viewer` (mandatory: glfw and
-opengl, optional: nanogui and nanovg).
+the dependencies of the `igl::opengl::glfw::Viewer`.
 
 We recommend you to install libigl using git via:
 
     git clone --recursive https://github.com/libigl/libigl.git
+    cd libigl/
+    git checkout 6ebc585611d27d8e2038bbbf9cb4910c51713848
+    cd ..
 
 If you have installed libigl at `/path/to/libigl/` then a good place to clone
 this library is `/path/to/libigl-example-project/`.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ the dependencies of the `igl::opengl::glfw::Viewer`.
 
 We recommend you to install libigl using git via:
 
-    git clone --recursive https://github.com/libigl/libigl.git
+    git clone https://github.com/libigl/libigl.git
     cd libigl/
     git checkout 6ebc585611d27d8e2038bbbf9cb4910c51713848
+    git submodule update --init --recursive
     cd ..
 
 If you have installed libigl at `/path/to/libigl/` then a good place to clone

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,4 @@
-#include <igl/viewer/Viewer.h>
+#include <igl/opengl/glfw/Viewer.h>
 
 int main(int argc, char *argv[])
 {
@@ -27,8 +27,8 @@ int main(int argc, char *argv[])
     2,8,4).finished().array()-1;
 
   // Plot the mesh
-  igl::viewer::Viewer viewer;
-  viewer.data.set_mesh(V, F);
-  viewer.data.set_face_based(true);
+  igl::opengl::glfw::Viewer viewer;
+  viewer.data().set_mesh(V, F);
+  viewer.data().set_face_based(true);
   viewer.launch();
 }


### PR DESCRIPTION
Having libigl as a submodule is useful to make sure the example is always in sync with a working version of libigl.