### PR TITLE
Add CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,16 @@
+version: 0.0.{build}
+os: Visual Studio 2017
+test: off
+clone_folder: C:\projects\libigl-example-project
+install:
+  - git clone --recursive --depth=3 https://github.com/libigl/libigl.git C:\projects\libigl-example-project\libigl
+  - git submodule update --init --recursive
+
+build_script:
+  - cd c:\projects\libigl-example-project
+  - mkdir build
+  - cd build
+  - cmake -G "Visual Studio 15 2017 Win64" ../
+  - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - set MSBuildOptions=/v:m /p:Configuration=Debug /logger:%MSBuildLogger%
+  - msbuild %MSBuildOptions% example.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+dist: trusty
+sudo: false
+language: cpp
+matrix:
+  include:
+  - os: linux
+    compiler: gcc # 4.8
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+        - xorg-dev
+        - libglu1-mesa-dev
+    env:
+    - MATRIX_EVAL=""
+  - os: linux
+    compiler: gcc-7
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+        - gcc-7
+        - g++-7
+        - xorg-dev
+        - libglu1-mesa-dev
+    env:
+    - MATRIX_EVAL="export CC=gcc-7 && CXX=g++-7"
+  - os: osx
+    compiler: clang
+    env:
+    - MATRIX_EVAL=""
+
+install:
+- git clone --recursive --depth=3 https://github.com/libigl/libigl.git
+- eval "${MATRIX_EVAL}"
+
+script:
+# Tutorials and tests
+- mkdir build
+- cd build
+- cmake ..
+- make -j 2
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # libigl example project
+[![Build Status](https://travis-ci.org/libigl/libigl-example-project.svg?branch=master)](https://travis-ci.org/libigl/libigl-example-project)
+[![Build status](https://ci.appveyor.com/api/projects/status/libigl/libigl-example-project?svg=true)](https://ci.appveyor.com/project/libigl/libigl-example-project/branch/master)
 
 A blank project example showing how to use libigl and cmake. Feel free and
 encouraged to copy or fork this project as a way of starting a new personal


### PR DESCRIPTION
Added CI builds on Travis-CI (ubuntu & macOS) and AppVeyor (Visual Studio 15 2017 Win64) similar to the builds in https://github.com/libigl/libigl.
@alecjacobson sugguested CI support (libigl/libigl-example-project#20). Please let me know if this is what you want or how it can be improved 😃 

output:
- https://travis-ci.com/BruegelN/libigl-example-project
- https://ci.appveyor.com/project/BruegelN/libigl-example-project