### PR TITLE
rework FindLIBIGL.cmake

### DIFF
--- a/cmake/FindLIBIGL.cmake
+++ b/cmake/FindLIBIGL.cmake
@@ -9,11 +9,9 @@ endif()
 
 find_path(LIBIGL_INCLUDE_DIR igl/readOBJ.h
     HINTS
-        ENV LIBIGL
-        ENV LIBIGLROOT
-        ENV LIBIGL_ROOT
         ENV LIBIGL_DIR
     PATHS
+        ${LIBIGL_DIR}
         ${CMAKE_SOURCE_DIR}/../..
         ${CMAKE_SOURCE_DIR}/..
         ${CMAKE_SOURCE_DIR}

--- a/cmake/FindLIBIGL.cmake
+++ b/cmake/FindLIBIGL.cmake
@@ -28,7 +28,7 @@ find_path(LIBIGL_INCLUDE_DIR igl/readOBJ.h
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LIBIGL
-    "\nlibigl not found --- You can download it using:\n\tgit clone --recursive https://github.com/libigl/libigl.git ${CMAKE_SOURCE_DIR}/../libigl"
+    "\nlibigl not found --- You can download it using:\n\tgit clone https://github.com/libigl/libigl.git ${CMAKE_SOURCE_DIR}/../libigl"
     LIBIGL_INCLUDE_DIR)
 mark_as_advanced(LIBIGL_INCLUDE_DIR)
 

--- a/cmake/FindLIBIGL.cmake
+++ b/cmake/FindLIBIGL.cmake
@@ -9,9 +9,9 @@ endif()
 
 find_path(LIBIGL_INCLUDE_DIR igl/readOBJ.h
     HINTS
+        ${LIBIGL_DIR}
         ENV LIBIGL_DIR
     PATHS
-        ${LIBIGL_DIR}
         ${CMAKE_SOURCE_DIR}/../..
         ${CMAKE_SOURCE_DIR}/..
         ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
* removed `--recursive` option when cloning libigl, it isn't required anymore.
* `FindLIBIG.cmake` will check for the value of LIBIGL_DIR, either as an environment variable or if passed via `cmake ../ -DLIBIGL_DIR=~/foo/libigl`. Previously it was quite confusing that you've could pass the include folder of libigl via `cmake ../ -DLIBIGL_INCLUDE_DIR=~/foo/libigl/include` or set the libigl root via an ENV. See also https://github.com/libigl/libigl.github.io/pull/20.

@jdumas if you have any further suggestions I'm happy to hear :) 

_____
Later on I'll verify that it works as expected on macOS and Windows10 as well and remove the __[WIP]__
