### PR TITLE
Remove _bin from executable name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,5 @@ find_package(LIBIGL REQUIRED QUIET)
 
 # Add your project files
 file(GLOB SRCFILES *.cpp)
-add_executable(${PROJECT_NAME}_bin ${SRCFILES})
+add_executable(${PROJECT_NAME} ${SRCFILES})
 target_link_libraries(${PROJECT_NAME} igl::core igl::opengl_glfw)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,4 @@ find_package(LIBIGL REQUIRED QUIET)
 # Add your project files
 file(GLOB SRCFILES *.cpp)
 add_executable(${PROJECT_NAME}_bin ${SRCFILES})
-target_link_libraries(${PROJECT_NAME}_bin igl::core igl::opengl_glfw)
+target_link_libraries(${PROJECT_NAME} igl::core igl::opengl_glfw)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This should find and build the dependencies and create a `example_bin` binary.
 
 From within the `build` directory just issue:
 
-    ./example_bin
+    ./example
 
 A glfw app should launch displaying a 3D cube.


### PR DESCRIPTION
Similar PR forthcoming for libigl's tutorial https://github.com/libigl/libigl/pull/1594

This removes the `_bin` suffix. Not sure if this will affect Windows, doesn't bother Mac OS X at all.